### PR TITLE
Fixed missing hostname prevents saving of content with Gutenberg.

### DIFF
--- a/src/Varnish.php
+++ b/src/Varnish.php
@@ -39,8 +39,11 @@ class Varnish {
     if (defined('VARNISH_HOST')) {
       $varnish_purge_url = rtrim(VARNISH_HOST, '/') . $path;
     }
-    else {
+    elseif (isset($url_parts['host'])) {
       $varnish_purge_url = 'http://' . $url_parts['host'] . $path;
+    }
+    else {
+      return;
     }
 
     $request_options = [


### PR DESCRIPTION
Problem
* When saving content with Gutenberg and having WP_DEBUG enabled and no VARNISH_HOST configured in wp-config.php, the plugin causes a PHP Notice, which prevents the content from being saved, as the JSON response cannot be parsed due to the error output.

Proposed solution
1. Prevent the PHP Notice.

Notes
* This is an edge-case scenario; the constants are normally configured differently on production sites.