### PR TITLE
Fixed page of form is not purged when updating Gravityform.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /*
   Plugin Name: Varnish Cache
   Plugin URI: https://wordpress.org/plugins/varnish-cache/
-  Version: 1.0.1
+  Version: 1.0.2
   Text Domain: varnish-cache
   Network: true
   Description: Integrates the Varnish Cache with WordPress.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, tha_sun, techpriester, Ipstenu, DH-Shredder
 Tags: varnish, cache, proxy, reverse-proxy, purge, ban, performance, speed, PageSpeed, caching
 Requires at least: 4.0
 Tested up to: 4.9
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 
 Integrates the Varnish Cache with WordPress.
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -230,7 +230,7 @@ class Plugin {
     //   [gravityform id=\"48\"
     //   <!-- wp:html --> [gravityform id="48"
     //   <!-- wp:gravityforms/form {"formId":"48","formPreview":false}
-    $search_term = '([[]gravityform id=)(?:\\\\\\\\)?"' . $form['id'] . '(?:\\\\\\\\)?"';
+    $search_term = '[[]gravityform id=(\\\\\\\\)?"' . $form['id'] . '(\\\\\\\\)?"';
     $search_term .= '|wp\:gravityforms\/form {"formId":"' . $form['id'] . '"';
     $target_pages = $wpdb->get_col("
       SELECT p.ID FROM {$wpdb->posts} p


### PR DESCRIPTION
### Problem
* The page rendering a Gravityform is not invalidated in the Varnish cache when the form is saved.

### Cause
* The REGEXP expression `?:` is not supported by MySQL 5.7.

### Example
Before
```sql
SELECT p.ID FROM wp_posts p
      WHERE p.post_type IN ('page', 'post')
        AND p.post_status = 'publish'
        AND p.post_content REGEXP '([[]gravityform id=)(?:\\\\)?"610(?:\\\\)?"|wp\:gravityforms\/form {"formId":"610"';
```

After
```sql
SELECT p.ID FROM wp_posts p
      WHERE p.post_type IN ('page', 'post')
        AND p.post_status = 'publish'
        AND p.post_content REGEXP '[[]gravityform id=(\\\\)?"610(\\\\)?"|wp\:gravityforms\/form {"formId":"610"'
```
